### PR TITLE
feat(telegram): add reply context to agent

### DIFF
--- a/packages/api/src/channels/__tests__/message-router.service.test.ts
+++ b/packages/api/src/channels/__tests__/message-router.service.test.ts
@@ -98,6 +98,7 @@ describe('MessageRouterService', () => {
         channelId: 'channel-1',
         userId: 'user-1',
         input: 'Hello agent',
+        replyContext: undefined,
       }),
     );
     expect(channel.sendMessage).toHaveBeenCalledWith({
@@ -108,6 +109,44 @@ describe('MessageRouterService', () => {
         sessionId: 'session-1',
       },
     });
+  });
+
+  it('forwards reply context to agent runner', async () => {
+    const user = { id: 'user-1', telegramId: '123456', isActive: true };
+    const userAgent = { agentDefinitionId: 'agent-1' };
+    const runResult = {
+      sessionId: 'session-1',
+      output: 'Context received',
+      status: 'completed',
+      responseMessageId: 'msg-abc',
+      tokenUsage: { input: 10, output: 5 },
+    };
+
+    mockUserRepo.findByTelegramId.mockResolvedValue(user);
+    mockUserAgentRepo.findByUserId.mockResolvedValue(userAgent);
+    mockAgentRunner.run.mockResolvedValue(runResult);
+
+    const channel = mockChannel();
+    const router = createRouter();
+
+    await router.handleInbound(
+      mockInbound({
+        replyCtx: {
+          from: { id: 42, date: 1_700_000_000, isBot: false },
+          text: 'Original message',
+        },
+      }),
+      channel,
+    );
+
+    expect(mockAgentRunner.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyContext: {
+          from: { id: 42, date: 1_700_000_000, isBot: false },
+          text: 'Original message',
+        },
+      }),
+    );
   });
 
   it('falls back to agentRunId when responseMessageId is missing', async () => {

--- a/packages/api/src/channels/message-router.service.ts
+++ b/packages/api/src/channels/message-router.service.ts
@@ -118,6 +118,7 @@ export class MessageRouterService {
         channel: channel.type,
         chatId: senderId,
         userName: senderName,
+        replyContext: message.replyCtx,
       });
 
       const responseText = result.output ?? 'Agent completed without output.';

--- a/packages/api/src/channels/telegram/telegram.adapter.ts
+++ b/packages/api/src/channels/telegram/telegram.adapter.ts
@@ -1,4 +1,5 @@
 import { Bot } from 'grammy';
+import type { Message } from 'grammy/types';
 import { createLogger } from '@clawix/shared';
 import type {
   ChannelAdapter,
@@ -16,6 +17,19 @@ import {
 } from '../utils/message-chunker.js';
 
 const logger = createLogger('channels:telegram');
+
+const extractReplyContext = (message: Message): InboundMessage['replyCtx'] => {
+  if (!message?.reply_to_message || !message.reply_to_message.text) {
+    return undefined;
+  }
+  const replyInfo = message.reply_to_message;
+  return {
+    from: replyInfo.from
+      ? { isBot: replyInfo.from?.is_bot ?? false, id: replyInfo.from.id, date: replyInfo.date }
+      : undefined,
+    text: replyInfo.text!,
+  };
+};
 
 /**
  * Create a Telegram channel adapter using grammy.
@@ -61,7 +75,7 @@ export function createTelegramAdapter(config: ChannelAdapterConfig): ChannelAdap
       senderName: [from.first_name, from.last_name].filter(Boolean).join(' '),
       text: ctx.message.text,
       timestamp: new Date(ctx.message.date * 1000),
-      rawPayload: ctx.message,
+      replyCtx: extractReplyContext(ctx.message),
     };
 
     try {

--- a/packages/api/src/engine/__tests__/agent-runner.service.test.ts
+++ b/packages/api/src/engine/__tests__/agent-runner.service.test.ts
@@ -731,6 +731,25 @@ describe('AgentRunnerService', () => {
     );
   });
 
+  it('passes replyContext through to context builder', async () => {
+    await service.run({
+      ...defaultOptions,
+      replyContext: {
+        from: { id: 42, date: 1_700_000_000, isBot: false },
+        text: 'Original message',
+      },
+    });
+
+    expect(mocks.mockContextBuilder.buildMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyContext: {
+          from: { id: 42, date: 1_700_000_000, isBot: false },
+          text: 'Original message',
+        },
+      }),
+    );
+  });
+
   // ---------------------------------------------------------------- //
   //  Test 20: Sub-agents get empty history instead of parent session  //
   // ---------------------------------------------------------------- //

--- a/packages/api/src/engine/__tests__/context-builder.service.test.ts
+++ b/packages/api/src/engine/__tests__/context-builder.service.test.ts
@@ -147,6 +147,24 @@ describe('ContextBuilderService', () => {
       expect(userContent).toContain('Hello');
     });
 
+    it('should include reply context when provided', async () => {
+      const params: ContextBuildParams = {
+        ...baseParams,
+        replyContext: {
+          from: { id: 42, date: 1_700_000_000, isBot: false },
+          text: 'Original message text',
+        },
+      };
+
+      const result = await service.buildMessages(params);
+
+      const userContent = result[result.length - 1]!.content as string;
+      expect(userContent).toContain('[Reply Context]');
+      expect(userContent).toContain('Original Sender ID: 42');
+      expect(userContent).toContain('Original Sender Is Bot: false');
+      expect(userContent).toContain('Original Message: Original message text');
+    });
+
     it('should include Server Time in runtime context', async () => {
       const result = await service.buildMessages(baseParams);
 

--- a/packages/api/src/engine/agent-runner.service.ts
+++ b/packages/api/src/engine/agent-runner.service.ts
@@ -237,6 +237,7 @@ export class AgentRunnerService {
         channel: options.channel,
         chatId: options.chatId,
         userName: options.userName,
+        replyContext: options.replyContext,
         workspacePath: isSubAgent ? undefined : workspacePaths?.localPath,
         isSubAgent,
         isScheduledTask: options.isScheduledTask,

--- a/packages/api/src/engine/agent-runner.types.ts
+++ b/packages/api/src/engine/agent-runner.types.ts
@@ -1,4 +1,4 @@
-import type { AgentStatus, TokenUsageRecord } from '@clawix/shared';
+import type { AgentStatus, InboundMessage, TokenUsageRecord } from '@clawix/shared';
 
 import type { MessageStore } from './message-store/message-store.js';
 
@@ -27,6 +27,8 @@ export interface RunOptions {
   readonly chatId?: string;
   /** User display name. Defaults to 'System'. */
   readonly userName?: string;
+  /** Optional reply context from channel adapters (e.g., Telegram reply_to_message). */
+  readonly replyContext?: InboundMessage['replyCtx'];
   /** When true, this is a re-invocation triggered by sub-agent result delivery. Reuses existing session. */
   readonly isReinvocation?: boolean;
   /** Token budget for this run (inputTokens + outputTokens). Omit for no limit. */

--- a/packages/api/src/engine/context-builder.service.ts
+++ b/packages/api/src/engine/context-builder.service.ts
@@ -56,7 +56,13 @@ export class ContextBuilderService {
       isScheduledTask,
       params.workers,
     );
-    const userContent = await this.buildUserMessage(input, channel, chatId, userName);
+    const userContent = await this.buildUserMessage(
+      input,
+      channel,
+      chatId,
+      userName,
+      params.replyContext,
+    );
 
     const systemMessage: ChatMessage = { role: 'system', content: systemPrompt };
     const userMessage: ChatMessage = { role: 'user', content: userContent };
@@ -370,6 +376,7 @@ export class ContextBuilderService {
     channel: string,
     chatId: string,
     userName: string,
+    replyContext?: ContextBuildParams['replyContext'],
   ): Promise<string> {
     const now = new Date();
     const { defaultTimezone } = await this.systemSettingsService.get();
@@ -397,7 +404,18 @@ export class ContextBuilderService {
       `User: ${userName}`,
     ].join('\n');
 
-    return `${runtimeContext}\n\n${input}`;
+    if (!replyContext) {
+      return `${runtimeContext}\n\n${input}`;
+    }
+
+    const replyContextLines = [
+      '[Reply Context]',
+      `Original Sender ID: ${replyContext.from?.id ?? 'unknown'}`,
+      `Original Sender Is Bot: ${replyContext.from?.isBot ?? false}`,
+      `Original Message: ${replyContext.text}`,
+    ].join('\n');
+
+    return `${runtimeContext}\n\n${replyContextLines}\n\n${input}`;
   }
 }
 

--- a/packages/api/src/engine/context-builder.types.ts
+++ b/packages/api/src/engine/context-builder.types.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from '@clawix/shared';
+import type { ChatMessage, InboundMessage } from '@clawix/shared';
 
 /** Fields from AgentDefinition needed by ContextBuilder. */
 export interface ContextAgentDef {
@@ -19,6 +19,8 @@ export interface ContextBuildParams {
   readonly chatId?: string;
   /** User display name. Defaults to 'System'. */
   readonly userName?: string;
+  /** Optional channel reply metadata (e.g., Telegram reply_to_message). */
+  readonly replyContext?: InboundMessage['replyCtx'];
   /** Resolved local workspace path for loading bootstrap files. */
   readonly workspacePath?: string;
   /** When true, skips bootstrap files and adds sub-agent framing to the system prompt. */

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -15,6 +15,10 @@ export interface Channel {
 // ------------------------------------------------------------------ //
 
 /** Inbound message received from a channel adapter. */
+export interface ReplyContext {
+  from?: { id: number; date: number; isBot: boolean };
+  text: string;
+}
 export interface InboundMessage {
   readonly channelType: ChannelType;
   readonly channelMessageId: string;
@@ -22,6 +26,7 @@ export interface InboundMessage {
   readonly senderName: string;
   readonly text: string;
   readonly timestamp: Date;
+  readonly replyCtx?: ReplyContext;
   readonly rawPayload?: unknown;
 }
 


### PR DESCRIPTION
Adds support for Telegram's reply_to_message metadata throughout the agent pipeline, so the LLM is aware of which message a user is replying to.

## Changes:

Telegram adapter — extracts reply_to_message from grammy's Message type into a normalized ReplyContext object
Shared types — added ReplyContext interface and optional replyCtx field on InboundMessage
Message router — forwards replyCtx from the inbound message into agentRunner.run()
Agent runner types — added replyContext to RunOptions
Agent runner service — passes replyContext through to the context builder
Context builder types — added replyContext to ContextBuildParams
Context builder service — renders a [Reply Context] block in the user prompt when reply metadata is present (original input text unchanged)
Tests — added unit tests covering the new propagation path in router, runner, and context builder

## Testing:
Manually tested with Telegram — the agent correctly receives and responds with awareness of the message being replied to.