### PR TITLE
feat(skills): move custom skills into workspace, add CRUD API, add kimi-code provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,11 @@ NODE_ENV=development
 LOG_LEVEL=debug
 # Production: NODE_ENV=production, LOG_LEVEL=info
 
-# Web (Next.js)
+# Web (Next.js) — both vars are baked into the bundle at `next build` time.
+# Rebuild the web image (`docker compose -f docker-compose.prod.yml build web`)
+# whenever you change them.
 NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_WS_URL=ws://localhost:3001
 
 # CORS (comma-separated origins allowed to call the API)
 CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -125,17 +125,26 @@ Pluggable tools with approval workflows. Bundle built-in skills, create custom o
 
 - **Node.js 20+** and **pnpm 9+**
 - **Docker** (for agent containers, PostgreSQL, and Redis)
+- **Docker Desktop** (user-friendly platform for container management)
 
 > **Self-hosting in production?** Skip ahead to [Production Deployment](#production-deployment-first-run) — the installer handles `.env` generation, image builds, and bootstrap for you. The steps below are for local development.
 
 ### 1. Clone & Install
 
 ```bash
-git clone https://github.com/clawix/clawix.git
+# 1. Clone the repository
+git clone https://github.com/ClawixAI/clawix.git
 cd clawix
 
-# One-command setup (installs deps, copies .env, starts infra)
-./scripts/setup-dev.sh
+# 2. Prepare your environment file
+cp .env.example .env
+# Edit .env — set at least one AI provider key:
+#   ANTHROPIC_API_KEY, OPENAI_API_KEY, or ZAI_CODING_API_KEY
+# (The installer will guide you through all required values interactively
+#  if you prefer to skip manual editing)
+
+# 3. Run the interactive installer
+pnpm run install:clawix
 ```
 
 <details>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,6 +95,7 @@ services:
       dockerfile: infra/docker/web/Dockerfile
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-}
     image: clawix-web:latest
     container_name: clawix-web
     restart: unless-stopped

--- a/infra/docker/web/Dockerfile
+++ b/infra/docker/web/Dockerfile
@@ -32,6 +32,8 @@ WORKDIR /app
 # Build-time environment variables
 ARG NEXT_PUBLIC_API_URL=http://localhost:3001
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ARG NEXT_PUBLIC_WS_URL
+ENV NEXT_PUBLIC_WS_URL=${NEXT_PUBLIC_WS_URL}
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "db:migrate": "pnpm --filter @clawix/api exec prisma migrate dev && pnpm --filter @clawix/api exec prisma generate",
     "db:seed": "pnpm --filter @clawix/api exec prisma db seed",
     "db:reset": "pnpm --filter @clawix/api exec prisma migrate reset --force",
-    "db:studio": "pnpm --filter @clawix/api exec prisma studio"
+    "db:studio": "pnpm --filter @clawix/api exec prisma studio",
+    "migrate:custom-skills": "tsx scripts/migrate-custom-skills.ts"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/api/prisma/seed.ts
+++ b/packages/api/prisma/seed.ts
@@ -4,7 +4,6 @@
  * Run: pnpm exec prisma db seed
  */
 import dotenv from 'dotenv';
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../src/generated/prisma/client.js';
@@ -311,15 +310,8 @@ async function main(): Promise<void> {
   });
   console.log('  UserAgents: admin + developer bound to Primary Assistant');
 
-  // --- Custom Skills Directories ---
-  const workspaceBase = process.env['WORKSPACE_BASE_PATH'] ?? './data';
-  const customSkillsBase =
-    process.env['SKILLS_CUSTOM_HOST_DIR'] ?? path.resolve(workspaceBase, 'skills/custom');
-  for (const user of [admin, developer, viewer]) {
-    const userSkillsDir = path.join(customSkillsBase, user.id);
-    await fs.mkdir(userSkillsDir, { recursive: true });
-  }
-  console.log(`  Skills: custom skill directories created under ${customSkillsBase}`);
+  // Custom skill directories are created lazily inside each user's workspace
+  // (<workspace>/skills/) on first agent run — see agent-runner.service.ts.
 
   // --- Provider Configs (org-level, conditional on env vars) ---
   // providerSeeds, customName, customBase defined above alongside policy creation

--- a/packages/api/src/admin/admin.service.ts
+++ b/packages/api/src/admin/admin.service.ts
@@ -16,7 +16,6 @@ import { encryptChannelConfig, maskChannelConfig } from '../channels/channel-con
 import { GroupRepository } from '../db/group.repository.js';
 import { PolicyRepository } from '../db/policy.repository.js';
 import { UserRepository } from '../db/user.repository.js';
-import { SkillLoaderService } from '../engine/skill-loader.service.js';
 import { BCRYPT_SALT_ROUNDS_DEFAULT } from '../auth/auth.constants.js';
 
 type SafeUser = Omit<User, 'passwordHash'>;
@@ -46,7 +45,6 @@ export class AdminService {
     private readonly channelManager: ChannelManagerService,
     private readonly groupRepo: GroupRepository,
     private readonly policyRepo: PolicyRepository,
-    private readonly skillLoader: SkillLoaderService,
     private readonly config: ConfigService,
   ) {
     this.saltRounds = Number(
@@ -77,9 +75,6 @@ export class AdminService {
       role: input.role,
       policyId: input.policyId,
     });
-
-    // Create the user's custom skill directory
-    await this.skillLoader.ensureUserSkillDir(user.id);
 
     return this.stripPassword(user);
   }

--- a/packages/api/src/agents/__tests__/agents.service.test.ts
+++ b/packages/api/src/agents/__tests__/agents.service.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+
+import { AgentsService } from '../agents.service.js';
+import type { AgentDefinitionRepository } from '../../db/agent-definition.repository.js';
+import type { AgentRunRepository } from '../../db/agent-run.repository.js';
+import type { UserAgentRepository } from '../../db/user-agent.repository.js';
+import type { PrismaService } from '../../prisma/prisma.service.js';
+
+// ------------------------------------------------------------------ //
+//  Helpers                                                            //
+// ------------------------------------------------------------------ //
+
+const ownerId = 'user-owner';
+const otherUserId = 'user-other';
+const adminId = 'user-admin';
+const agentId = 'agent-1';
+
+function makeAgent(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: agentId,
+    name: 'Worker A',
+    role: 'worker',
+    isOfficial: false,
+    createdById: ownerId,
+    isActive: true,
+    description: '',
+    systemPrompt: 'sys',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4',
+    skillIds: [],
+    maxTokensPerRun: 100000,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeService(opts: {
+  agentDef?: ReturnType<typeof makeAgent>;
+  existsForUser?: boolean;
+  findByAgentDefinitionId?: ReturnType<typeof vi.fn>;
+}) {
+  const agentDefRepo = {
+    findById: vi.fn().mockResolvedValue(opts.agentDef ?? makeAgent()),
+  } as unknown as AgentDefinitionRepository;
+
+  const agentRunRepo = {
+    findByAgentDefinitionId:
+      opts.findByAgentDefinitionId ??
+      vi.fn().mockResolvedValue({
+        data: [],
+        meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+      }),
+  } as unknown as AgentRunRepository;
+
+  const userAgentRepo = {
+    existsForUser: vi.fn().mockResolvedValue(opts.existsForUser ?? false),
+  } as unknown as UserAgentRepository;
+
+  const prisma = {} as unknown as PrismaService;
+
+  const service = new AgentsService(agentDefRepo, agentRunRepo, userAgentRepo, prisma);
+  return { service, agentDefRepo, agentRunRepo, userAgentRepo };
+}
+
+// ------------------------------------------------------------------ //
+//  Tests                                                              //
+// ------------------------------------------------------------------ //
+
+describe('AgentsService.getAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('admin can read any agent', async () => {
+    const { service } = makeService({});
+    await expect(service.getAgent(agentId, adminId, 'admin')).resolves.toBeDefined();
+  });
+
+  it('owner can read their custom agent', async () => {
+    const { service } = makeService({});
+    await expect(service.getAgent(agentId, ownerId, 'user')).resolves.toBeDefined();
+  });
+
+  it('any user can read an official agent', async () => {
+    const { service } = makeService({ agentDef: makeAgent({ isOfficial: true }) });
+    await expect(service.getAgent(agentId, otherUserId, 'user')).resolves.toBeDefined();
+  });
+
+  it('assigned user can read someone else’s custom agent', async () => {
+    const { service } = makeService({ existsForUser: true });
+    await expect(service.getAgent(agentId, otherUserId, 'user')).resolves.toBeDefined();
+  });
+
+  it('throws ForbiddenException when user is neither owner, official, nor assigned', async () => {
+    const { service } = makeService({ existsForUser: false });
+    await expect(service.getAgent(agentId, otherUserId, 'user')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});
+
+describe('AgentsService.listAgentRuns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes userId to the repository for non-admin callers', async () => {
+    const findByAgentDefinitionId = vi.fn().mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    });
+    const { service } = makeService({ findByAgentDefinitionId });
+
+    await service.listAgentRuns(agentId, { page: 1, limit: 10 }, otherUserId, 'user');
+
+    expect(findByAgentDefinitionId).toHaveBeenCalledWith(
+      agentId,
+      { page: 1, limit: 10 },
+      otherUserId,
+    );
+  });
+
+  it('omits userId scoping for admin callers', async () => {
+    const findByAgentDefinitionId = vi.fn().mockResolvedValue({
+      data: [],
+      meta: { total: 0, page: 1, limit: 10, totalPages: 0 },
+    });
+    const { service } = makeService({ findByAgentDefinitionId });
+
+    await service.listAgentRuns(agentId, { page: 1, limit: 10 }, adminId, 'admin');
+
+    expect(findByAgentDefinitionId).toHaveBeenCalledWith(
+      agentId,
+      { page: 1, limit: 10 },
+      undefined,
+    );
+  });
+});

--- a/packages/api/src/agents/agents.controller.ts
+++ b/packages/api/src/agents/agents.controller.ts
@@ -111,13 +111,16 @@ export class AgentsController {
   listRuns(
     @Param('id') id: string,
     @Query(new ZodValidationPipe(paginationSchema)) query: PaginationInput,
+    @Req() req: AuthRequest,
   ) {
-    return this.agentsService.listAgentRuns(id, query);
+    const { user } = req;
+    return this.agentsService.listAgentRuns(id, query, user.sub, user.role);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.agentsService.getAgent(id);
+  findOne(@Param('id') id: string, @Req() req: AuthRequest) {
+    const { user } = req;
+    return this.agentsService.getAgent(id, user.sub, user.role);
   }
 
   @Post()

--- a/packages/api/src/agents/agents.service.ts
+++ b/packages/api/src/agents/agents.service.ts
@@ -33,8 +33,19 @@ export class AgentsService {
     return this.agentDefRepo.findAll(pagination, options);
   }
 
-  async getAgent(id: string): Promise<AgentDefinition> {
-    return this.agentDefRepo.findById(id);
+  async getAgent(id: string, userId?: string, userRole?: string): Promise<AgentDefinition> {
+    const agent = await this.agentDefRepo.findById(id);
+    if (userRole === 'admin' || !userId) {
+      return agent;
+    }
+    if (agent.isOfficial || agent.createdById === userId) {
+      return agent;
+    }
+    const assigned = await this.userAgentRepo.existsForUser(userId, id);
+    if (!assigned) {
+      throw new ForbiddenException('You do not have access to this agent');
+    }
+    return agent;
   }
 
   async createAgent(
@@ -73,8 +84,11 @@ export class AgentsService {
   async listAgentRuns(
     agentDefinitionId: string,
     pagination: PaginationInput,
+    userId?: string,
+    userRole?: string,
   ): Promise<PaginatedResponse<AgentRun>> {
-    return this.agentRunRepo.findByAgentDefinitionId(agentDefinitionId, pagination);
+    const scopeUserId = userRole === 'admin' ? undefined : userId;
+    return this.agentRunRepo.findByAgentDefinitionId(agentDefinitionId, pagination, scopeUserId);
   }
 
   async listUserAgents(userId: string, userRole: string) {

--- a/packages/api/src/db/__tests__/agent-run.repository.test.ts
+++ b/packages/api/src/db/__tests__/agent-run.repository.test.ts
@@ -98,6 +98,22 @@ describe('AgentRunRepository', () => {
         expect.objectContaining({ where: { agentDefinitionId: 'agent-1' } }),
       );
     });
+
+    it('should additionally scope by session.userId when userId is provided', async () => {
+      mockPrisma.agentRun.findMany.mockResolvedValue([mockAgentRun]);
+      mockPrisma.agentRun.count.mockResolvedValue(1);
+
+      await repository.findByAgentDefinitionId('agent-1', { page: 1, limit: 10 }, 'user-1');
+
+      expect(mockPrisma.agentRun.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { agentDefinitionId: 'agent-1', session: { userId: 'user-1' } },
+        }),
+      );
+      expect(mockPrisma.agentRun.count).toHaveBeenCalledWith({
+        where: { agentDefinitionId: 'agent-1', session: { userId: 'user-1' } },
+      });
+    });
   });
 
   describe('create', () => {

--- a/packages/api/src/db/agent-run.repository.ts
+++ b/packages/api/src/db/agent-run.repository.ts
@@ -101,9 +101,13 @@ export class AgentRunRepository {
   async findByAgentDefinitionId(
     agentDefinitionId: string,
     pagination: PaginationInput,
+    userId?: string,
   ): Promise<PaginatedResponse<AgentRun>> {
     const paginationArgs = buildPaginationArgs(pagination);
-    const where = { agentDefinitionId };
+    const where: Prisma.AgentRunWhereInput = {
+      agentDefinitionId,
+      ...(userId ? { session: { userId } } : {}),
+    };
 
     const [data, total] = await Promise.all([
       this.prisma.agentRun.findMany({

--- a/packages/api/src/db/user-agent.repository.ts
+++ b/packages/api/src/db/user-agent.repository.ts
@@ -79,6 +79,13 @@ export class UserAgentRepository {
     });
   }
 
+  async existsForUser(userId: string, agentDefinitionId: string): Promise<boolean> {
+    const count = await this.prisma.userAgent.count({
+      where: { userId, agentDefinitionId },
+    });
+    return count > 0;
+  }
+
   async create(data: CreateUserAgentInput): Promise<UserAgent> {
     try {
       return await this.prisma.userAgent.create({

--- a/packages/api/src/engine/__tests__/agent-runner.service.test.ts
+++ b/packages/api/src/engine/__tests__/agent-runner.service.test.ts
@@ -730,7 +730,6 @@ describe('AgentRunnerService', () => {
         workspaceHostPath: '/host/data/users/user-1/workspace',
         skillMounts: expect.objectContaining({
           builtinHostPath: expect.any(String),
-          customHostPath: expect.any(String),
         }),
       },
     );
@@ -762,7 +761,6 @@ describe('AgentRunnerService', () => {
         workspaceHostPath: '/host/data/users/user-1/workspace',
         skillMounts: expect.objectContaining({
           builtinHostPath: expect.any(String),
-          customHostPath: expect.any(String),
         }),
       },
     );

--- a/packages/api/src/engine/__tests__/container-runner-skills.test.ts
+++ b/packages/api/src/engine/__tests__/container-runner-skills.test.ts
@@ -34,7 +34,6 @@ describe('buildDockerRunArgs - skill mounts', () => {
       validatedMounts: [],
       skillMounts: {
         builtinHostPath: '/host/skills/builtin',
-        customHostPath: '/host/skills/custom/user1',
       },
     });
     expect(args).toContain('-v');
@@ -42,18 +41,15 @@ describe('buildDockerRunArgs - skill mounts', () => {
     expect(builtinMountIndex).toBeGreaterThan(-1);
   });
 
-  it('adds custom skills mount as read-write', () => {
+  it('does not emit a /skills/custom mount', () => {
     const args = buildDockerRunArgs({
       agentDef: mockAgentDef,
       containerName: 'test-container',
       validatedMounts: [],
-      skillMounts: {
-        builtinHostPath: '/host/skills/builtin',
-        customHostPath: '/host/skills/custom/user1',
-      },
+      skillMounts: { builtinHostPath: '/host/skills/builtin' },
     });
-    const customMountIndex = args.indexOf('/host/skills/custom/user1:/skills/custom');
-    expect(customMountIndex).toBeGreaterThan(-1);
+    expect(args.join(' ')).not.toContain('/skills/custom');
+    expect(args.join(' ')).toContain('/host/skills/builtin:/skills/builtin:ro');
   });
 
   it('omits skill mounts when not provided', () => {

--- a/packages/api/src/engine/__tests__/context-builder-skills.test.ts
+++ b/packages/api/src/engine/__tests__/context-builder-skills.test.ts
@@ -20,7 +20,7 @@ describe('ContextBuilderService - skill summary integration', () => {
       buildSkillsSummary: vi
         .fn()
         .mockResolvedValue(
-          '<skills><skill><name>test</name><description>Test</description><location>/skills/builtin/test/SKILL.md</location><source>builtin</source></skill></skills>',
+          '<skills><skill><name>test</name><description>Test</description><location>/workspace/skills/test/SKILL.md</location><source>custom</source></skill></skills>',
         ),
     };
 
@@ -38,6 +38,7 @@ describe('ContextBuilderService - skill summary integration', () => {
       history: [],
       input: 'Hello',
       userId: 'user1',
+      workspacePath: '/tmp/workspace-user1',
     };
 
     const messages = await service.buildMessages(params);
@@ -46,9 +47,12 @@ describe('ContextBuilderService - skill summary integration', () => {
     expect(systemContent).toContain('<skills>');
     expect(systemContent).toContain('Skills are NOT agents');
     expect(systemContent).toContain('call read_file on its SKILL.md location');
+    expect(systemContent).toContain('/workspace/skills/');
     const skillIndex = systemContent.indexOf('<skills>');
     const promptIndex = systemContent.indexOf('Be helpful.');
     expect(skillIndex).toBeGreaterThan(promptIndex);
+    // Loader is called with <workspace>/skills as customDir
+    expect(mockSkillLoader.buildSkillsSummary).toHaveBeenCalledWith('/tmp/workspace-user1/skills');
   });
 
   it('omits skill section when no skills available', async () => {

--- a/packages/api/src/engine/__tests__/file-io.test.ts
+++ b/packages/api/src/engine/__tests__/file-io.test.ts
@@ -86,9 +86,9 @@ describe('validateContainerPath', () => {
     );
   });
 
-  it('allows /skills/custom paths', () => {
-    expect(validateContainerPath('/skills/custom/my-skill/SKILL.md')).toBe(
-      '/skills/custom/my-skill/SKILL.md',
+  it('allows /workspace/skills paths (the new custom-skill location)', () => {
+    expect(validateContainerPath('/workspace/skills/my-skill/SKILL.md')).toBe(
+      '/workspace/skills/my-skill/SKILL.md',
     );
   });
 

--- a/packages/api/src/engine/__tests__/skill-loader.service.test.ts
+++ b/packages/api/src/engine/__tests__/skill-loader.service.test.ts
@@ -74,7 +74,7 @@ describe('SkillLoaderService', () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-test-'));
     builtinDir = path.join(tmpDir, 'builtin');
-    customDir = path.join(tmpDir, 'custom');
+    customDir = path.join(tmpDir, 'workspace', 'skills');
     await fs.mkdir(builtinDir, { recursive: true });
     await fs.mkdir(customDir, { recursive: true });
   });
@@ -95,33 +95,32 @@ describe('SkillLoaderService', () => {
       'summarize',
       '---\nname: summarize\ndescription: Summarize text\n---',
     );
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(1);
     expect(skills[0]!.name).toBe('summarize');
     expect(skills[0]!.source).toBe('builtin');
   });
 
-  it('discovers custom user skills', async () => {
-    const userDir = path.join(customDir, 'user1');
-    await createSkill(userDir, 'my-tool', '---\nname: my-tool\ndescription: My custom tool\n---');
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+  it('discovers custom user skills at /workspace/skills/<name>', async () => {
+    await createSkill(customDir, 'my-tool', '---\nname: my-tool\ndescription: My custom tool\n---');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(1);
     expect(skills[0]!.name).toBe('my-tool');
     expect(skills[0]!.source).toBe('custom');
+    expect(skills[0]!.path).toBe('/workspace/skills/my-tool/SKILL.md');
   });
 
   it('custom overrides builtin by directory name', async () => {
     await createSkill(builtinDir, 'summarize', '---\nname: summarize\ndescription: Built-in\n---');
-    const userDir = path.join(customDir, 'user1');
     await createSkill(
-      userDir,
+      customDir,
       'summarize',
       '---\nname: summarize\ndescription: Custom override\n---',
     );
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(1);
     expect(skills[0]!.source).toBe('custom');
     expect(skills[0]!.description).toBe('Custom override');
@@ -129,72 +128,72 @@ describe('SkillLoaderService', () => {
 
   it('skips directories without SKILL.md', async () => {
     await fs.mkdir(path.join(builtinDir, 'empty-dir'), { recursive: true });
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(0);
   });
 
   it('skips skills with invalid frontmatter', async () => {
     await createSkill(builtinDir, 'bad-skill', '---\nname: Invalid Name!\ndescription: Bad\n---');
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(0);
   });
 
   it('enforces max skills per user limit', async () => {
-    const userDir = path.join(customDir, 'user1');
     for (let i = 0; i < 5; i++) {
       await createSkill(
-        userDir,
+        customDir,
         `skill-${i}`,
         `---\nname: skill-${i}\ndescription: Skill ${i}\n---`,
       );
     }
-    const service = new SkillLoaderService(builtinDir, customDir, 3);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 3);
+    const skills = await service.listSkills(customDir);
     const customSkills = skills.filter((s) => s.source === 'custom');
     expect(customSkills.length).toBe(3);
   });
 
-  it('user isolation - user2 cannot see user1 skills', async () => {
-    const user1Dir = path.join(customDir, 'user1');
-    await createSkill(
-      user1Dir,
-      'private-tool',
-      '---\nname: private-tool\ndescription: Private\n---',
-    );
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user2');
-    expect(skills.filter((s) => s.name === 'private-tool')).toHaveLength(0);
+  it('returns only builtin when customDir does not exist', async () => {
+    await createSkill(builtinDir, 'b', '---\nname: b\ndescription: B\n---');
+    const missingCustom = path.join(tmpDir, 'no-such-dir');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(missingCustom);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.source).toBe('builtin');
   });
 
-  it('builds XML summary with correct format', async () => {
+  it('builds XML summary with /workspace/skills path for custom', async () => {
+    await createSkill(customDir, 'my-tool', '---\nname: my-tool\ndescription: My tool\n---');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const summary = await service.buildSkillsSummary(customDir);
+    expect(summary).toContain('<location>/workspace/skills/my-tool/SKILL.md</location>');
+    expect(summary).toContain('<source>custom</source>');
+  });
+
+  it('builds XML summary with /skills/builtin path for builtin', async () => {
     await createSkill(
       builtinDir,
       'summarize',
       '---\nname: summarize\ndescription: Summarize text\n---',
     );
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const summary = await service.buildSkillsSummary('user1');
-    expect(summary).toContain('<skills>');
-    expect(summary).toContain('<name>summarize</name>');
-    expect(summary).toContain('<description>Summarize text</description>');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const summary = await service.buildSkillsSummary(customDir);
     expect(summary).toContain('<location>/skills/builtin/summarize/SKILL.md</location>');
     expect(summary).toContain('<source>builtin</source>');
-    expect(summary).toContain('</skills>');
   });
 
   it('returns empty string when no skills found', async () => {
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const summary = await service.buildSkillsSummary('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const summary = await service.buildSkillsSummary(customDir);
     expect(summary).toBe('');
   });
 
   it('skips symlinked skill directories', async () => {
     await createSkill(builtinDir, 'real-skill', '---\nname: real-skill\ndescription: Real\n---');
     await fs.symlink(path.join(builtinDir, 'real-skill'), path.join(builtinDir, 'symlink-skill'));
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const skills = await service.listSkills('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const skills = await service.listSkills(customDir);
     expect(skills).toHaveLength(1);
     expect(skills[0]!.name).toBe('real-skill');
   });
@@ -205,8 +204,8 @@ describe('SkillLoaderService', () => {
       'xml-test',
       '---\nname: xml-test\ndescription: Parse <data> & format\n---',
     );
-    const service = new SkillLoaderService(builtinDir, customDir, 50);
-    const summary = await service.buildSkillsSummary('user1');
+    const service = new SkillLoaderService(builtinDir, 50);
+    const summary = await service.buildSkillsSummary(customDir);
     expect(summary).toContain('&lt;data&gt;');
     expect(summary).toContain('&amp;');
     expect(summary).not.toContain('<data>');

--- a/packages/api/src/engine/agent-runner.service.ts
+++ b/packages/api/src/engine/agent-runner.service.ts
@@ -307,29 +307,61 @@ export class AgentRunnerService {
         });
       }
 
-      // Compute skill mount paths (same local/host duality as workspace-resolver.ts)
+      // REMOVE AFTER 2026-Q3 MIGRATION COMPLETE — auto-migrates legacy custom-skill location
+      // into <workspace>/skills/. See docs/specs/2026-04-29-custom-skills-in-workspace-design.md.
+      if (workspacePaths !== undefined) {
+        const legacyDir = path.resolve(
+          process.env['WORKSPACE_BASE_PATH'] ?? './data',
+          'skills/custom',
+          userId,
+        );
+        const legacyEntries = await fs.promises.readdir(legacyDir).catch(() => null);
+        if (legacyEntries && legacyEntries.length > 0) {
+          const targetSkillsDir = path.join(workspacePaths.localPath, 'skills');
+          await fs.promises.mkdir(targetSkillsDir, { recursive: true });
+          for (const name of legacyEntries) {
+            const source = path.join(legacyDir, name);
+            const target = path.join(targetSkillsDir, name);
+            const exists = await fs.promises
+              .stat(target)
+              .then(() => true)
+              .catch(() => false);
+            if (exists) {
+              logger.warn(
+                { userId, name },
+                'Skill collision during lazy migration — leaving source in place',
+              );
+              continue;
+            }
+            try {
+              await fs.promises.rename(source, target);
+              logger.info({ userId, name }, 'Lazy-migrated legacy custom skill into workspace');
+            } catch (err) {
+              // ENOENT: another concurrent agent run for the same user already moved this skill.
+              // Treat as success and continue.
+              if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                continue;
+              }
+              throw err;
+            }
+          }
+          await fs.promises.rmdir(legacyDir).catch(() => undefined);
+        }
+      }
+
+      // Compute builtin skill mount paths (same local/host duality as workspace-resolver.ts).
+      // Custom skills now live inside the workspace at <workspace>/skills/, so they ride along
+      // on the workspace mount and don't need a separate -v flag.
       const skillsBuiltinLocalDir =
         process.env['SKILLS_BUILTIN_DIR'] ?? path.resolve(process.cwd(), '../../skills/builtin');
       const skillsBuiltinHostDir = process.env['SKILLS_BUILTIN_HOST_DIR'] ?? skillsBuiltinLocalDir;
 
-      const skillsCustomLocalBase =
-        process.env['SKILLS_CUSTOM_DIR'] ??
-        path.resolve(process.env['WORKSPACE_BASE_PATH'] ?? './data', 'skills/custom');
-      const skillsCustomHostBase =
-        process.env['SKILLS_CUSTOM_HOST_DIR'] ??
-        path.resolve(process.env['WORKSPACE_HOST_BASE_PATH'] ?? skillsCustomLocalBase);
+      // Ensure <workspace>/skills exists so the loader scan finds it
+      if (workspacePaths !== undefined) {
+        await fs.promises.mkdir(path.join(workspacePaths.localPath, 'skills'), { recursive: true });
+      }
 
-      const skillsCustomUserLocalDir = path.join(skillsCustomLocalBase, userId);
-      const skillsCustomUserHostDir = path.join(skillsCustomHostBase, userId);
-
-      // Ensure user's custom skills directory exists and is writable by container user (1000:1000)
-      await fs.promises.mkdir(skillsCustomUserLocalDir, { recursive: true });
-      await this.makeWorkspaceWritable(skillsCustomUserLocalDir);
-
-      const skillMounts = {
-        builtinHostPath: skillsBuiltinHostDir,
-        customHostPath: skillsCustomUserHostDir,
-      };
+      const skillMounts = { builtinHostPath: skillsBuiltinHostDir };
 
       if (!usePool) {
         containerId = await this.containerRunner.start(sharedAgentDef, [], {

--- a/packages/api/src/engine/container-runner.ts
+++ b/packages/api/src/engine/container-runner.ts
@@ -67,7 +67,6 @@ export interface StartOptions {
   /** Skill directory mounts (trusted system mounts, bypass validateMounts). */
   readonly skillMounts?: {
     readonly builtinHostPath: string;
-    readonly customHostPath: string;
   };
 }
 
@@ -392,7 +391,6 @@ export function buildDockerRunArgs(params: DockerRunArgsParams): string[] {
   // Mount skill directories (trusted system mounts, not validated through mount-security)
   if (params.skillMounts !== undefined) {
     args.push('-v', `${params.skillMounts.builtinHostPath}:/skills/builtin:ro`);
-    args.push('-v', `${params.skillMounts.customHostPath}:/skills/custom`);
   }
 
   for (const mount of validatedMounts) {

--- a/packages/api/src/engine/context-builder.service.ts
+++ b/packages/api/src/engine/context-builder.service.ts
@@ -115,13 +115,14 @@ export class ContextBuilderService {
     }
 
     // 6. Skills summary (optional)
-    const skillsSummary = await this.skillLoader.buildSkillsSummary(userId);
+    const customDir = workspacePath ? path.join(workspacePath, 'skills') : '';
+    const skillsSummary = await this.skillLoader.buildSkillsSummary(customDir);
     if (skillsSummary) {
       sections.push(
         '# Skills\n\n' +
           'Skills are NOT agents — do NOT use the spawn tool for skills.\n' +
           'To use a skill: call read_file on its SKILL.md location, then follow the instructions inside.\n' +
-          'To create new skills: write them under /skills/custom/ (writable). /skills/builtin/ is read-only.\n\n' +
+          'To create new skills: write them under /workspace/skills/ (writable, lives inside your workspace). /skills/builtin/ is read-only.\n\n' +
           skillsSummary,
       );
     }

--- a/packages/api/src/engine/engine.module.ts
+++ b/packages/api/src/engine/engine.module.ts
@@ -12,6 +12,7 @@ import { CronGuardService } from './cron-guard.service.js';
 import { CronSchedulerService } from './cron-scheduler.service.js';
 import { CronTaskProcessorService } from './cron-task-processor.service.js';
 import { SkillLoaderService } from './skill-loader.service.js';
+import { DEFAULT_MAX_SKILLS_PER_USER } from './skill-loader.types.js';
 import { ContainerRunner } from './container-runner.js';
 import { ContainerPoolService } from './container-pool.service.js';
 import { SessionManagerService } from './session-manager.service.js';
@@ -53,11 +54,13 @@ import { DuckDuckGoProvider } from './tools/web/providers/duckduckgo.js';
       useFactory: () => {
         const builtinDir =
           process.env['SKILLS_BUILTIN_DIR'] ?? path.resolve(process.cwd(), '../../skills/builtin');
-        const customDir =
-          process.env['SKILLS_CUSTOM_DIR'] ??
-          path.resolve(process.env['WORKSPACE_BASE_PATH'] ?? './data', 'skills/custom');
-        const maxPerUser = parseInt(process.env['MAX_SKILLS_PER_USER'] ?? '50', 10);
-        return new SkillLoaderService(builtinDir, customDir, maxPerUser);
+        const rawMax = parseInt(
+          process.env['MAX_SKILLS_PER_USER'] ?? String(DEFAULT_MAX_SKILLS_PER_USER),
+          10,
+        );
+        const maxPerUser =
+          Number.isFinite(rawMax) && rawMax > 0 ? rawMax : DEFAULT_MAX_SKILLS_PER_USER;
+        return new SkillLoaderService(builtinDir, maxPerUser);
       },
     },
     {

--- a/packages/api/src/engine/providers/__tests__/provider-factory.test.ts
+++ b/packages/api/src/engine/providers/__tests__/provider-factory.test.ts
@@ -113,4 +113,14 @@ describe('createProvider', () => {
     expect(provider).toBeInstanceOf(OpenAIResponsesProvider);
     expect(provider.name).toBe('openai-responses');
   });
+
+  it('creates an AnthropicProvider for "kimi-code" with default base URL', () => {
+    const provider = createProvider('kimi-code', API_KEY);
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it('creates an AnthropicProvider for "kimi-code" with custom baseURL', () => {
+    const provider = createProvider('kimi-code', API_KEY, 'https://custom.kimi.com/v1');
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
 });

--- a/packages/api/src/engine/providers/provider-factory.ts
+++ b/packages/api/src/engine/providers/provider-factory.ts
@@ -11,6 +11,7 @@ import { OpenAIResponsesProvider } from './openai-responses-provider.js';
 import { isCodexModel } from './openai-responses-utils.js';
 
 const ZAI_CODING_DEFAULT_BASE_URL = 'https://api.z.ai/api/coding/paas/v4';
+const KIMI_CODE_DEFAULT_BASE_URL = 'https://api.kimi.com/coding';
 
 /**
  * Instantiate an {@link LLMProvider} by provider name.
@@ -44,6 +45,9 @@ export function createProvider(
 
     case 'gemini':
       return new GeminiProvider(apiKey, baseURL);
+
+    case 'kimi-code':
+      return new AnthropicProvider(apiKey, baseURL ?? KIMI_CODE_DEFAULT_BASE_URL);
 
     default:
       if (!baseURL) {

--- a/packages/api/src/engine/skill-loader.service.ts
+++ b/packages/api/src/engine/skill-loader.service.ts
@@ -90,25 +90,14 @@ const logger = createLogger('engine:skill-loader');
 export class SkillLoaderService {
   constructor(
     private readonly builtinDir: string,
-    private readonly customDir: string,
     private readonly maxSkillsPerUser: number = DEFAULT_MAX_SKILLS_PER_USER,
   ) {}
 
-  /**
-   * Ensures the user's custom skill directory exists.
-   * Call this when creating a new user.
-   */
-  async ensureUserSkillDir(userId: string): Promise<void> {
-    const userSkillDir = path.join(this.customDir, userId);
-    await fs.mkdir(userSkillDir, { recursive: true });
-    logger.info({ userId, userSkillDir }, 'Ensured user skill directory exists');
-  }
-
-  async listSkills(userId: string): Promise<readonly SkillInfo[]> {
+  async listSkills(customDir: string): Promise<readonly SkillInfo[]> {
     const customSkills = await this.scanDirectory(
-      path.join(this.customDir, userId),
+      customDir,
       'custom',
-      '/skills/custom',
+      '/workspace/skills',
       this.maxSkillsPerUser,
     );
     const customDirNames = new Set(customSkills.map((s) => s.dirName));
@@ -120,8 +109,8 @@ export class SkillLoaderService {
     ];
   }
 
-  async buildSkillsSummary(userId: string): Promise<string> {
-    const skills = await this.listSkills(userId);
+  async buildSkillsSummary(customDir: string): Promise<string> {
+    const skills = await this.listSkills(customDir);
     if (skills.length === 0) return '';
     const lines = ['<skills>'];
     for (const skill of skills) {

--- a/packages/api/src/engine/skill-loader.types.ts
+++ b/packages/api/src/engine/skill-loader.types.ts
@@ -20,4 +20,4 @@ export const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 export const MAX_SKILL_NAME_LENGTH = 64;
 export const MAX_SKILL_DESCRIPTION_LENGTH = 1024;
 export const MAX_SKILL_FILE_SIZE = 1024 * 1024; // 1MB
-export const DEFAULT_MAX_SKILLS_PER_USER = 100;
+export const DEFAULT_MAX_SKILLS_PER_USER = 50;

--- a/packages/api/src/provider-config/provider-config.service.ts
+++ b/packages/api/src/provider-config/provider-config.service.ts
@@ -220,6 +220,7 @@ export class ProviderConfigService {
       { provider: 'anthropic', displayName: 'Anthropic', envKey: 'ANTHROPIC_API_KEY' },
       { provider: 'openai', displayName: 'OpenAI', envKey: 'OPENAI_API_KEY' },
       { provider: 'zai-coding', displayName: 'Z.AI Coding Plan', envKey: 'ZAI_CODING_API_KEY' },
+      { provider: 'kimi-code', displayName: 'Kimi Coding Plan', envKey: 'KIMI_CODE_API_KEY' },
     ];
 
     let isFirst = true;

--- a/packages/api/src/skills/__tests__/skills.service.test.ts
+++ b/packages/api/src/skills/__tests__/skills.service.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { SkillsService } from '../skills.service.js';
+
+function makeUserAgentRepo(workspacePath: string) {
+  return {
+    findByUserId: vi.fn(async () => ({ workspacePath })),
+  } as unknown as import('../../db/user-agent.repository.js').UserAgentRepository;
+}
+
+describe('SkillsService', () => {
+  let tmpDir: string;
+  let workspaceDir: string;
+  let skillsDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skills-service-'));
+    workspaceDir = path.join(tmpDir, 'workspace');
+    skillsDir = path.join(workspaceDir, 'skills');
+    await fs.mkdir(skillsDir, { recursive: true });
+    vi.stubEnv('WORKSPACE_BASE_PATH', tmpDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a skill with template SKILL.md', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'my-skill', description: 'Does a thing' });
+    const content = await fs.readFile(path.join(skillsDir, 'my-skill', 'SKILL.md'), 'utf-8');
+    expect(content).toContain('name: my-skill');
+    expect(content).toContain('description: Does a thing');
+  });
+
+  it('rejects creating a skill with an existing dir name', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'dup', description: 'd' });
+    await expect(service.create('user1', { name: 'dup', description: 'd' })).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('enforces MAX_SKILLS_PER_USER on create', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 2);
+    await service.create('user1', { name: 'a', description: 'a' });
+    await service.create('user1', { name: 'b', description: 'b' });
+    await expect(service.create('user1', { name: 'c', description: 'c' })).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('reads SKILL.md content for a custom skill', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'reader', description: 'r' });
+    const got = await service.read('user1', 'reader');
+    expect(got.dirName).toBe('reader');
+    expect(got.name).toBe('reader');
+    expect(got.description).toBe('r');
+    expect(got.content).toContain('name: reader');
+  });
+
+  it('throws NotFound when reading a missing skill', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await expect(service.read('user1', 'no-such')).rejects.toThrow(NotFoundException);
+  });
+
+  it('updates SKILL.md content with valid frontmatter', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'edit-me', description: 'orig' });
+    const newContent = `---\nname: edit-me\ndescription: updated\n---\n\n# Body`;
+    await service.updateContent('user1', 'edit-me', newContent);
+    const got = await service.read('user1', 'edit-me');
+    expect(got.description).toBe('updated');
+  });
+
+  it('rejects update with invalid frontmatter', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'edit-me', description: 'orig' });
+    await expect(service.updateContent('user1', 'edit-me', 'no frontmatter here')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('renames a skill directory and rewrites frontmatter name', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'old-name', description: 'd' });
+    await service.rename('user1', 'old-name', 'new-name');
+    const got = await service.read('user1', 'new-name');
+    expect(got.name).toBe('new-name');
+    const oldExists = await fs
+      .stat(path.join(skillsDir, 'old-name'))
+      .then(() => true)
+      .catch(() => false);
+    expect(oldExists).toBe(false);
+  });
+
+  it('rejects rename to existing dir name', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'a', description: 'd' });
+    await service.create('user1', { name: 'b', description: 'd' });
+    await expect(service.rename('user1', 'a', 'b')).rejects.toThrow(ConflictException);
+  });
+
+  it('deletes a skill directory recursively', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await service.create('user1', { name: 'goner', description: 'd' });
+    await service.delete('user1', 'goner');
+    const exists = await fs
+      .stat(path.join(skillsDir, 'goner'))
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+  });
+
+  it('rejects path traversal in dirName', async () => {
+    const service = new SkillsService(makeUserAgentRepo('workspace'), 50);
+    await expect(service.read('user1', '../escape')).rejects.toThrow(BadRequestException);
+  });
+});

--- a/packages/api/src/skills/skills.controller.ts
+++ b/packages/api/src/skills/skills.controller.ts
@@ -1,20 +1,71 @@
-import { Controller, Get, Req } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Req } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import * as path from 'path';
 
 import { SkillLoaderService } from '../engine/skill-loader.service.js';
+import { SkillsService } from './skills.service.js';
+import { UserAgentRepository } from '../db/user-agent.repository.js';
+import { resolveWorkspacePaths } from '../engine/workspace-resolver.js';
 import type { JwtPayload } from '../auth/auth.types.js';
+import { createSkillSchema, renameSkillSchema, updateSkillContentSchema } from '@clawix/shared';
 
 @ApiTags('skills')
 @Controller('api/v1/skills')
 export class SkillsController {
-  constructor(private readonly skillLoader: SkillLoaderService) {}
+  constructor(
+    private readonly skillLoader: SkillLoaderService,
+    private readonly skillsService: SkillsService,
+    private readonly userAgentRepo: UserAgentRepository,
+  ) {}
 
   @Get()
   async findAll(@Req() req: { user: JwtPayload }) {
-    const skills = await this.skillLoader.listSkills(req.user.sub);
-    return {
-      success: true,
-      data: skills,
-    };
+    const userAgent = await this.userAgentRepo.findByUserId(req.user.sub);
+    const customDir = userAgent
+      ? path.join(resolveWorkspacePaths(userAgent.workspacePath).localPath, 'skills')
+      : '';
+    const skills = await this.skillLoader.listSkills(customDir);
+    return { success: true, data: skills };
+  }
+
+  @Get(':dirName')
+  async read(@Req() req: { user: JwtPayload }, @Param('dirName') dirName: string) {
+    const data = await this.skillsService.read(req.user.sub, dirName);
+    return { success: true, data };
+  }
+
+  @Post()
+  async create(@Req() req: { user: JwtPayload }, @Body() body: unknown) {
+    const parsed = createSkillSchema.parse(body);
+    await this.skillsService.create(req.user.sub, parsed);
+    return { success: true };
+  }
+
+  @Put(':dirName/content')
+  async updateContent(
+    @Req() req: { user: JwtPayload },
+    @Param('dirName') dirName: string,
+    @Body() body: unknown,
+  ) {
+    const parsed = updateSkillContentSchema.parse(body);
+    await this.skillsService.updateContent(req.user.sub, dirName, parsed.content);
+    return { success: true };
+  }
+
+  @Patch(':dirName')
+  async rename(
+    @Req() req: { user: JwtPayload },
+    @Param('dirName') dirName: string,
+    @Body() body: unknown,
+  ) {
+    const parsed = renameSkillSchema.parse(body);
+    await this.skillsService.rename(req.user.sub, dirName, parsed.newName);
+    return { success: true };
+  }
+
+  @Delete(':dirName')
+  async delete(@Req() req: { user: JwtPayload }, @Param('dirName') dirName: string) {
+    await this.skillsService.delete(req.user.sub, dirName);
+    return { success: true };
   }
 }

--- a/packages/api/src/skills/skills.module.ts
+++ b/packages/api/src/skills/skills.module.ts
@@ -1,9 +1,26 @@
 import { Module } from '@nestjs/common';
 import { EngineModule } from '../engine/engine.module.js';
+import { DbModule, UserAgentRepository } from '../db/index.js';
+import { DEFAULT_MAX_SKILLS_PER_USER } from '../engine/skill-loader.types.js';
 import { SkillsController } from './skills.controller.js';
+import { SkillsService } from './skills.service.js';
 
 @Module({
-  imports: [EngineModule],
+  imports: [EngineModule, DbModule],
   controllers: [SkillsController],
+  providers: [
+    {
+      provide: SkillsService,
+      useFactory: (userAgentRepo: UserAgentRepository) => {
+        const rawMax = parseInt(
+          process.env['MAX_SKILLS_PER_USER'] ?? String(DEFAULT_MAX_SKILLS_PER_USER),
+          10,
+        );
+        const max = Number.isFinite(rawMax) && rawMax > 0 ? rawMax : DEFAULT_MAX_SKILLS_PER_USER;
+        return new SkillsService(userAgentRepo, max);
+      },
+      inject: [UserAgentRepository],
+    },
+  ],
 })
 export class SkillsModule {}

--- a/packages/api/src/skills/skills.service.ts
+++ b/packages/api/src/skills/skills.service.ts
@@ -1,0 +1,167 @@
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { UserAgentRepository } from '../db/user-agent.repository.js';
+import { resolveWorkspacePaths } from '../engine/workspace-resolver.js';
+import { ScopedFs } from '../workspace/scoped-fs.js';
+import { parseFrontmatter } from '../engine/skill-loader.service.js';
+import {
+  SKILL_NAME_PATTERN,
+  MAX_SKILL_NAME_LENGTH,
+  DEFAULT_MAX_SKILLS_PER_USER,
+} from '../engine/skill-loader.types.js';
+import type { CreateSkillInput, SkillReadResult } from '@clawix/shared';
+
+const SKILL_TEMPLATE = (name: string, description: string) =>
+  `---
+name: ${name}
+description: ${description}
+version: 1.0.0
+---
+
+# ${name}
+
+## Overview
+
+[Describe what this skill does and when to use it]
+
+## Usage
+
+[Instructions for the agent on how to use this skill]
+`;
+
+@Injectable()
+export class SkillsService {
+  constructor(
+    private readonly userAgentRepo: UserAgentRepository,
+    private readonly maxSkillsPerUser: number = DEFAULT_MAX_SKILLS_PER_USER,
+  ) {}
+
+  private validateName(name: string): void {
+    if (name.length === 0 || name.length > MAX_SKILL_NAME_LENGTH) {
+      throw new BadRequestException('Invalid skill name length');
+    }
+    if (!SKILL_NAME_PATTERN.test(name)) {
+      throw new BadRequestException('Invalid skill name format');
+    }
+  }
+
+  private async getScopedFs(userId: string): Promise<{ sfs: ScopedFs; basePath: string }> {
+    const userAgent = await this.userAgentRepo.findByUserId(userId);
+    if (!userAgent) {
+      throw new NotFoundException('No workspace found for this user');
+    }
+    const { localPath } = resolveWorkspacePaths(userAgent.workspacePath);
+    const skillsBase = path.join(localPath, 'skills');
+    await fs.mkdir(skillsBase, { recursive: true });
+    return { sfs: new ScopedFs(skillsBase), basePath: skillsBase };
+  }
+
+  async create(userId: string, input: CreateSkillInput): Promise<void> {
+    this.validateName(input.name);
+    const { sfs, basePath } = await this.getScopedFs(userId);
+
+    const existing = await fs.readdir(basePath, { withFileTypes: true }).catch(() => []);
+    const existingDirs = existing.filter((e) => e.isDirectory()).map((e) => e.name);
+    if (existingDirs.includes(input.name)) {
+      throw new ConflictException(`Skill "${input.name}" already exists`);
+    }
+    if (existingDirs.length >= this.maxSkillsPerUser) {
+      throw new BadRequestException(`Maximum ${this.maxSkillsPerUser} skills reached`);
+    }
+
+    await sfs.mkdir(`/${input.name}`);
+    await sfs.writeFile(`/${input.name}/SKILL.md`, SKILL_TEMPLATE(input.name, input.description));
+  }
+
+  async read(userId: string, dirName: string): Promise<SkillReadResult> {
+    this.validateName(dirName);
+    const { sfs } = await this.getScopedFs(userId);
+    const skillMdPath = `/${dirName}/SKILL.md`;
+    let content: string;
+    let stat: Awaited<ReturnType<typeof sfs.stat>>;
+    try {
+      stat = await sfs.stat(skillMdPath);
+      content = (await sfs.readFile(skillMdPath, 'utf-8')) as string;
+    } catch {
+      throw new NotFoundException(`Skill "${dirName}" not found`);
+    }
+    const fm = parseFrontmatter(content);
+    if (!fm) {
+      throw new BadRequestException('Skill has invalid frontmatter');
+    }
+    return {
+      dirName,
+      name: fm.name,
+      description: fm.description,
+      content,
+      modifiedAt: stat.mtime.toISOString(),
+    };
+  }
+
+  async updateContent(userId: string, dirName: string, content: string): Promise<void> {
+    this.validateName(dirName);
+    const fm = parseFrontmatter(content);
+    if (!fm) {
+      throw new BadRequestException('SKILL.md must include valid frontmatter (name + description)');
+    }
+    const { sfs } = await this.getScopedFs(userId);
+    const skillMdPath = `/${dirName}/SKILL.md`;
+    try {
+      await sfs.stat(skillMdPath);
+    } catch {
+      throw new NotFoundException(`Skill "${dirName}" not found`);
+    }
+    await sfs.writeFile(skillMdPath, content);
+  }
+
+  async rename(userId: string, dirName: string, newName: string): Promise<void> {
+    this.validateName(dirName);
+    this.validateName(newName);
+    if (dirName === newName) return;
+
+    const { sfs } = await this.getScopedFs(userId);
+    const sourceExists = await sfs
+      .stat(`/${dirName}`)
+      .then(() => true)
+      .catch(() => false);
+    if (!sourceExists) {
+      throw new NotFoundException(`Skill "${dirName}" not found`);
+    }
+    const targetExists = await sfs
+      .stat(`/${newName}`)
+      .then(() => true)
+      .catch(() => false);
+    if (targetExists) {
+      throw new ConflictException(`Skill "${newName}" already exists`);
+    }
+    await sfs.rename(`/${dirName}`, `/${newName}`);
+
+    // Rewrite frontmatter `name:` to match new dir name
+    const skillMdRel = `/${newName}/SKILL.md`;
+    const raw = (await sfs.readFile(skillMdRel, 'utf-8').catch(() => null)) as string | null;
+    if (raw === null) return;
+    const updated = raw.replace(/^(name:\s*).+$/m, `$1${newName}`);
+    await sfs.writeFile(skillMdRel, updated);
+  }
+
+  async delete(userId: string, dirName: string): Promise<void> {
+    this.validateName(dirName);
+    const { sfs } = await this.getScopedFs(userId);
+    const exists = await sfs
+      .stat(`/${dirName}`)
+      .then(() => true)
+      .catch(() => false);
+    if (!exists) {
+      throw new NotFoundException(`Skill "${dirName}" not found`);
+    }
+    await sfs.remove(`/${dirName}`);
+  }
+}

--- a/packages/shared/src/providers/__tests__/provider-registry.test.ts
+++ b/packages/shared/src/providers/__tests__/provider-registry.test.ts
@@ -223,6 +223,23 @@ describe('Gemini provider spec', () => {
   });
 });
 
+describe('Kimi Code provider spec', () => {
+  it('is registered by name', () => {
+    const spec = findProviderByName('kimi-code');
+    expect(spec).not.toBeNull();
+    expect(spec?.displayName).toBe('Kimi Coding Plan');
+    expect(spec?.envKey).toBe('KIMI_CODE_API_KEY');
+    expect(spec?.defaultBaseUrl).toBe('https://api.kimi.com/coding');
+    expect(spec?.supportsTools).toBe(true);
+    expect(spec?.supportsThinking).toBe(false);
+    expect(spec?.pricing).toBeNull();
+  });
+
+  it('appears in listProviders()', () => {
+    expect(listProviders().some((p) => p.name === 'kimi-code')).toBe(true);
+  });
+});
+
 describe('estimateCost', () => {
   it('should calculate cost for claude-opus-4', () => {
     // $15 per M input, $75 per M output

--- a/packages/shared/src/providers/provider-registry.ts
+++ b/packages/shared/src/providers/provider-registry.ts
@@ -109,6 +109,18 @@ const GEMINI_SPEC: ProviderSpec = {
   ],
 };
 
+const KIMI_CODE_SPEC: ProviderSpec = {
+  name: 'kimi-code',
+  displayName: 'Kimi Coding Plan',
+  modelPrefixes: [],
+  envKey: 'KIMI_CODE_API_KEY',
+  defaultBaseUrl: 'https://api.kimi.com/coding',
+  defaultModel: '',
+  supportsTools: true,
+  supportsThinking: false,
+  pricing: null,
+};
+
 const CUSTOM_SPEC: ProviderSpec = {
   name: 'custom',
   displayName: 'Custom',
@@ -124,6 +136,7 @@ const PROVIDERS: readonly ProviderSpec[] = [
   ANTHROPIC_SPEC,
   OPENAI_SPEC,
   ZAI_CODING_SPEC,
+  KIMI_CODE_SPEC,
   GEMINI_SPEC,
   CUSTOM_SPEC,
 ];

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -94,3 +94,16 @@ export {
   type DeleteInput,
   type UpdateContentInput,
 } from './workspace.schema.js';
+
+export {
+  skillNameSchema,
+  skillDescriptionSchema,
+  skillContentSchema,
+  createSkillSchema,
+  renameSkillSchema,
+  updateSkillContentSchema,
+  type CreateSkillInput,
+  type RenameSkillInput,
+  type UpdateSkillContentInput,
+  type SkillReadResult,
+} from './skill.schema.js';

--- a/packages/shared/src/schemas/skill.schema.ts
+++ b/packages/shared/src/schemas/skill.schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const skillNameSchema = z
+  .string()
+  .min(1, 'Name is required')
+  .max(64, 'Name must be 64 characters or fewer')
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'Name must be lowercase alphanumeric with hyphens');
+
+export const skillDescriptionSchema = z
+  .string()
+  .min(1, 'Description is required')
+  .max(1024, 'Description must be 1024 characters or fewer');
+
+export const skillContentSchema = z.string().max(1_048_576, 'SKILL.md must be 1 MB or less');
+
+export const createSkillSchema = z.object({
+  name: skillNameSchema,
+  description: skillDescriptionSchema,
+});
+export type CreateSkillInput = z.infer<typeof createSkillSchema>;
+
+export const renameSkillSchema = z.object({
+  newName: skillNameSchema,
+});
+export type RenameSkillInput = z.infer<typeof renameSkillSchema>;
+
+export const updateSkillContentSchema = z.object({
+  content: skillContentSchema,
+});
+export type UpdateSkillContentInput = z.infer<typeof updateSkillContentSchema>;
+
+export interface SkillReadResult {
+  readonly dirName: string;
+  readonly name: string;
+  readonly description: string;
+  readonly content: string;
+  readonly modifiedAt: string; // ISO 8601
+}

--- a/packages/web/src/app/(dashboard)/skills/page.tsx
+++ b/packages/web/src/app/(dashboard)/skills/page.tsx
@@ -1,35 +1,31 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { BookOpen, Loader2, Package, User, Wrench } from 'lucide-react';
+import { Loader2, Package, Plus, User, Wrench } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 import { authFetch } from '@/lib/auth';
-
-/* ------------------------------------------------------------------ */
-/*  Types                                                              */
-/* ------------------------------------------------------------------ */
-
-interface Skill {
-  name: string;
-  description: string;
-  path: string;
-  source: 'builtin' | 'custom';
-}
-
-/* ------------------------------------------------------------------ */
-/*  Page                                                               */
-/* ------------------------------------------------------------------ */
+import type { SkillReadResult } from '@clawix/shared';
+import { BuiltinCard, CustomCard, type Skill, dirNameFromPath } from './skills-cards';
+import { CreateDialog, EditDialog, RenameDialog, DeleteDialog } from './skills-dialogs';
 
 export default function SkillsPage() {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<{ dirName: string; content: string } | null>(null);
+  const [renameTarget, setRenameTarget] = useState<{ dirName: string } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ dirName: string; name: string } | null>(null);
+
   const fetchSkills = useCallback(async () => {
+    setLoading(true);
     try {
       const res = await authFetch<{ success: boolean; data: Skill[] }>('/api/v1/skills');
       setSkills(Array.isArray(res.data) ? res.data : []);
+      setError('');
     } catch {
       setError('Failed to load skills');
     } finally {
@@ -44,6 +40,18 @@ export default function SkillsPage() {
   const builtinSkills = skills.filter((s) => s.source === 'builtin');
   const customSkills = skills.filter((s) => s.source === 'custom');
 
+  const handleEditClick = async (skill: Skill) => {
+    const dirName = dirNameFromPath(skill.path);
+    try {
+      const res = await authFetch<{ success: boolean; data: SkillReadResult }>(
+        `/api/v1/skills/${dirName}`,
+      );
+      setEditTarget({ dirName, content: res.data.content });
+    } catch {
+      setError('Failed to load skill content');
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -57,9 +65,9 @@ export default function SkillsPage() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Skills</h1>
         <p className="text-sm text-muted-foreground">
-          Skills extend your agent&apos;s capabilities with specialized knowledge and workflows. Use{' '}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">/create-skill</code> in a
-          conversation to create new ones.
+          Skills extend your agent&apos;s capabilities with specialized knowledge and workflows.
+          Custom skills live inside your workspace under{' '}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">/skills/&lt;name&gt;</code>.
         </p>
       </div>
 
@@ -69,7 +77,7 @@ export default function SkillsPage() {
         </div>
       )}
 
-      {/* Builtin Skills */}
+      {/* Built-in */}
       <section className="flex flex-col gap-4">
         <div className="flex items-center gap-2">
           <Package className="size-4 text-muted-foreground" />
@@ -78,26 +86,31 @@ export default function SkillsPage() {
             {builtinSkills.length}
           </Badge>
         </div>
-
         {builtinSkills.length === 0 ? (
           <p className="text-sm text-muted-foreground">No built-in skills found.</p>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {builtinSkills.map((skill) => (
-              <SkillCard key={skill.path} skill={skill} />
+              <BuiltinCard key={skill.path} skill={skill} />
             ))}
           </div>
         )}
       </section>
 
-      {/* Custom Skills */}
+      {/* Custom */}
       <section className="flex flex-col gap-4">
-        <div className="flex items-center gap-2">
-          <User className="size-4 text-muted-foreground" />
-          <h2 className="text-lg font-semibold">Your Skills</h2>
-          <Badge variant="secondary" className="text-xs">
-            {customSkills.length}
-          </Badge>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <User className="size-4 text-muted-foreground" />
+            <h2 className="text-lg font-semibold">Your Skills</h2>
+            <Badge variant="secondary" className="text-xs">
+              {customSkills.length}
+            </Badge>
+          </div>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1 size-4" />
+            Create skill
+          </Button>
         </div>
 
         {customSkills.length === 0 ? (
@@ -105,46 +118,61 @@ export default function SkillsPage() {
             <CardContent className="flex flex-col items-center justify-center py-8 text-center">
               <Wrench className="mb-2 size-8 text-muted-foreground" />
               <p className="text-sm text-muted-foreground">
-                No custom skills yet. Type{' '}
-                <code className="rounded bg-muted px-1.5 py-0.5 text-xs">/skill-creator</code> in a
-                conversation to create one.
+                No custom skills yet. Click &quot;Create skill&quot; to add one.
               </p>
             </CardContent>
           </Card>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {customSkills.map((skill) => (
-              <SkillCard key={skill.path} skill={skill} />
-            ))}
+            {customSkills.map((skill) => {
+              const dirName = dirNameFromPath(skill.path);
+              return (
+                <CustomCard
+                  key={skill.path}
+                  skill={skill}
+                  dirName={dirName}
+                  onEdit={() => handleEditClick(skill)}
+                  onRename={() => setRenameTarget({ dirName })}
+                  onDelete={() => setDeleteTarget({ dirName, name: skill.name })}
+                />
+              );
+            })}
           </div>
         )}
       </section>
+
+      <CreateDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => {
+          setCreateOpen(false);
+          void fetchSkills();
+        }}
+      />
+      <EditDialog
+        target={editTarget}
+        onClose={() => setEditTarget(null)}
+        onSaved={() => {
+          setEditTarget(null);
+          void fetchSkills();
+        }}
+      />
+      <RenameDialog
+        target={renameTarget}
+        onClose={() => setRenameTarget(null)}
+        onRenamed={() => {
+          setRenameTarget(null);
+          void fetchSkills();
+        }}
+      />
+      <DeleteDialog
+        target={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onDeleted={() => {
+          setDeleteTarget(null);
+          void fetchSkills();
+        }}
+      />
     </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  SkillCard                                                          */
-/* ------------------------------------------------------------------ */
-
-function SkillCard({ skill }: { skill: Skill }) {
-  return (
-    <Card className="flex flex-col">
-      <CardHeader>
-        <div className="flex items-start justify-between">
-          <div className="flex size-10 items-center justify-center rounded-lg border bg-muted">
-            <BookOpen className="size-5 text-muted-foreground" />
-          </div>
-          <Badge variant={skill.source === 'builtin' ? 'outline' : 'secondary'}>
-            {skill.source}
-          </Badge>
-        </div>
-        <CardTitle className="text-base">{skill.name}</CardTitle>
-        <CardDescription className="line-clamp-3">{skill.description}</CardDescription>
-      </CardHeader>
-      <CardContent className="mt-auto">
-        <p className="truncate text-xs text-muted-foreground font-mono">{skill.path}</p>
-      </CardContent>
-    </Card>
   );
 }

--- a/packages/web/src/app/(dashboard)/skills/skills-cards.tsx
+++ b/packages/web/src/app/(dashboard)/skills/skills-cards.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import Link from 'next/link';
+import { BookOpen, FolderOpen, Pencil, Trash } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export interface Skill {
+  name: string;
+  description: string;
+  path: string;
+  source: 'builtin' | 'custom';
+}
+
+export function dirNameFromPath(skillPath: string): string {
+  const parts = skillPath.split('/').filter(Boolean);
+  if (parts.length < 2) {
+    // Defensive: caller should never pass malformed paths, but a non-empty fallback
+    // keeps the UI from emitting empty-string dirNames into URLs / API calls.
+    return '';
+  }
+  return parts[parts.length - 2] ?? '';
+}
+
+export function BuiltinCard({ skill }: { skill: Skill }) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between">
+          <div className="flex size-10 items-center justify-center rounded-lg border bg-muted">
+            <BookOpen className="size-5 text-muted-foreground" />
+          </div>
+          <Badge variant="outline">builtin</Badge>
+        </div>
+        <CardTitle className="text-base">{skill.name}</CardTitle>
+        <CardDescription className="line-clamp-3">{skill.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="truncate text-xs text-muted-foreground font-mono">{skill.path}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CustomCard({
+  skill,
+  dirName,
+  onEdit,
+  onRename,
+  onDelete,
+}: {
+  skill: Skill;
+  dirName: string;
+  onEdit: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex items-start justify-between">
+          <div className="flex size-10 items-center justify-center rounded-lg border bg-muted">
+            <BookOpen className="size-5 text-muted-foreground" />
+          </div>
+          <Badge variant="secondary">custom</Badge>
+        </div>
+        <CardTitle className="text-base">{skill.name}</CardTitle>
+        <CardDescription className="line-clamp-3">{skill.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="mt-auto">
+        <p className="truncate text-xs text-muted-foreground font-mono">{skill.path}</p>
+      </CardContent>
+      <CardFooter className="flex flex-wrap gap-2">
+        <Button size="sm" variant="outline" onClick={onEdit}>
+          <Pencil className="mr-1 size-3" />
+          Edit
+        </Button>
+        <Button size="sm" variant="outline" onClick={onRename}>
+          Rename
+        </Button>
+        <Button size="sm" variant="outline" onClick={onDelete}>
+          <Trash className="mr-1 size-3" />
+          Delete
+        </Button>
+        <Button size="sm" variant="ghost" asChild>
+          <Link href={`/workspace?path=/skills/${dirName}`}>
+            <FolderOpen className="mr-1 size-3" />
+            Manage files
+          </Link>
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/web/src/app/(dashboard)/skills/skills-dialogs.tsx
+++ b/packages/web/src/app/(dashboard)/skills/skills-dialogs.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { authFetch } from '@/lib/auth';
+
+const NAME_REGEX = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export function CreateDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setDescription('');
+      setErr('');
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    setErr('');
+    if (!NAME_REGEX.test(name)) {
+      setErr('Name must be lowercase alphanumeric with hyphens.');
+      return;
+    }
+    if (description.trim().length === 0) {
+      setErr('Description is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      await authFetch('/api/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), description: description.trim() }),
+      });
+      setName('');
+      setDescription('');
+      onCreated();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to create skill');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create skill</DialogTitle>
+          <DialogDescription>
+            Scaffolds a new skill under <code>/skills/&lt;name&gt;/SKILL.md</code> in your
+            workspace.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="skill-name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Textarea
+            placeholder="What does this skill do, and when should the agent use it?"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+          />
+          {err && <p className="text-sm text-destructive">{err}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 size-4 animate-spin" /> : null}
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function EditDialog({
+  target,
+  onClose,
+  onSaved,
+}: {
+  target: { dirName: string; content: string } | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [content, setContent] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    setContent(target?.content ?? '');
+    setErr('');
+  }, [target]);
+
+  if (!target) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setErr('');
+    try {
+      await authFetch(`/api/v1/skills/${target.dirName}/content`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      });
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="!w-[60vw] !max-w-none">
+        <DialogHeader>
+          <DialogTitle>Edit {target.dirName}/SKILL.md</DialogTitle>
+          <DialogDescription>
+            Frontmatter must remain valid (name, description). For more complex edits, use the
+            workspace file editor.
+          </DialogDescription>
+        </DialogHeader>
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="min-h-[60vh] font-mono text-sm"
+        />
+        {err && <p className="text-sm text-destructive">{err}</p>}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 size-4 animate-spin" /> : null}
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function RenameDialog({
+  target,
+  onClose,
+  onRenamed,
+}: {
+  target: { dirName: string } | null;
+  onClose: () => void;
+  onRenamed: () => void;
+}) {
+  const [newName, setNewName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    setNewName(target?.dirName ?? '');
+    setErr('');
+  }, [target]);
+
+  if (!target) return null;
+
+  const handleSubmit = async () => {
+    setErr('');
+    if (!NAME_REGEX.test(newName)) {
+      setErr('Name must be lowercase alphanumeric with hyphens.');
+      return;
+    }
+    setSaving(true);
+    try {
+      await authFetch(`/api/v1/skills/${target.dirName}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newName }),
+      });
+      onRenamed();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to rename');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename skill</DialogTitle>
+          <DialogDescription>
+            The directory and the <code>name:</code> frontmatter field will both be updated.
+          </DialogDescription>
+        </DialogHeader>
+        <Input value={newName} onChange={(e) => setNewName(e.target.value)} />
+        {err && <p className="text-sm text-destructive">{err}</p>}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 size-4 animate-spin" /> : null}
+            Rename
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function DeleteDialog({
+  target,
+  onClose,
+  onDeleted,
+}: {
+  target: { dirName: string; name: string } | null;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState('');
+
+  if (!target) return null;
+
+  const handleConfirm = async () => {
+    setSaving(true);
+    setErr('');
+    try {
+      await authFetch(`/api/v1/skills/${target.dirName}`, { method: 'DELETE' });
+      onDeleted();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to delete');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete skill</DialogTitle>
+          <DialogDescription>
+            Permanently deletes <strong>{target.name}</strong> and all its files. This cannot be
+            undone.
+          </DialogDescription>
+        </DialogHeader>
+        {err && <p className="text-sm text-destructive">{err}</p>}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => void handleConfirm()} disabled={saving}>
+            {saving ? <Loader2 className="mr-1 size-4 animate-spin" /> : null}
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/(dashboard)/workspace/page.tsx
+++ b/packages/web/src/app/(dashboard)/workspace/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 import { FolderOpen, Loader2 } from 'lucide-react';
 import { authFetch, getAccessToken } from '@/lib/auth';
 import { ApiError } from '@/lib/api';
@@ -32,8 +33,10 @@ const FileEditor = dynamic(() => import('./file-editor').then((m) => ({ default:
   ssr: false,
 });
 
-export default function WorkspacePage() {
-  const [currentPath, setCurrentPath] = useState('/');
+function WorkspacePageContent() {
+  const searchParams = useSearchParams();
+  const initialPath = searchParams.get('path') ?? '/';
+  const [currentPath, setCurrentPath] = useState(initialPath);
   const [listing, setListing] = useState<DirectoryListing | null>(null);
   const [selectedFile, setSelectedFile] = useState<FileContent | null>(null);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -342,8 +345,8 @@ export default function WorkspacePage() {
   );
 
   useEffect(() => {
-    fetchDirectory('/');
-  }, [fetchDirectory]);
+    fetchDirectory(initialPath);
+  }, [fetchDirectory, initialPath]);
 
   return (
     <div className="flex h-full flex-col gap-4 p-6">
@@ -513,5 +516,19 @@ export default function WorkspacePage() {
         onEdit={handleEdit}
       />
     </div>
+  );
+}
+
+export default function WorkspacePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      <WorkspacePageContent />
+    </Suspense>
   );
 }

--- a/packages/web/src/components/ui/textarea.tsx
+++ b/packages/web/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/scripts/migrate-custom-skills.ts
+++ b/scripts/migrate-custom-skills.ts
@@ -1,0 +1,78 @@
+// scripts/migrate-custom-skills.ts
+//
+// Moves legacy custom skills from <WORKSPACE_BASE_PATH>/skills/custom/{userId}/...
+// into <WORKSPACE_BASE_PATH>/users/{userId}/workspace/skills/...
+//
+// Idempotent: re-running is a no-op if there is nothing to move.
+// Collisions: if the target skill directory already exists, the source is left
+// in place and a warning is logged.
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+async function main() {
+  const base = process.env['WORKSPACE_BASE_PATH'] ?? './data';
+  const legacyRoot = path.resolve(base, 'skills/custom');
+
+  let userDirs: string[];
+  try {
+    userDirs = await fs.readdir(legacyRoot);
+  } catch {
+    console.log(`[migrate] No legacy directory at ${legacyRoot} — nothing to do.`);
+    return;
+  }
+
+  let moved = 0;
+  let skipped = 0;
+
+  for (const userId of userDirs) {
+    const sourceUserDir = path.join(legacyRoot, userId);
+    const sourceStat = await fs.stat(sourceUserDir).catch(() => null);
+    if (!sourceStat || !sourceStat.isDirectory()) continue;
+
+    const skillEntries = await fs.readdir(sourceUserDir, { withFileTypes: true });
+    const realSkills = skillEntries.filter((e) => e.isDirectory());
+    if (realSkills.length === 0) {
+      // Nothing to migrate for this user; let the cleanup block below handle the empty source dir.
+      continue;
+    }
+
+    const targetSkillsDir = path.resolve(base, 'users', userId, 'workspace', 'skills');
+    await fs.mkdir(targetSkillsDir, { recursive: true });
+
+    for (const entry of realSkills) {
+      const source = path.join(sourceUserDir, entry.name);
+      const target = path.join(targetSkillsDir, entry.name);
+
+      const targetExists = await fs
+        .stat(target)
+        .then(() => true)
+        .catch(() => false);
+      if (targetExists) {
+        console.warn(
+          `[migrate] SKIP collision: ${target} already exists; leaving ${source} in place.`,
+        );
+        skipped++;
+        continue;
+      }
+      await fs.rename(source, target);
+      console.log(`[migrate] Moved ${source} -> ${target}`);
+      moved++;
+    }
+
+    // Try to clean up empty source dir
+    const remaining = await fs.readdir(sourceUserDir).catch(() => []);
+    if (remaining.length === 0) await fs.rmdir(sourceUserDir).catch(() => undefined);
+  }
+
+  // Try to clean up empty legacy root
+  const remainingRoot = await fs.readdir(legacyRoot).catch(() => []);
+  if (remainingRoot.length === 0) await fs.rmdir(legacyRoot).catch(() => undefined);
+
+  console.log(`[migrate] Done. Moved ${moved} skill(s), skipped ${skipped} collision(s).`);
+}
+
+main().catch((err) => {
+  console.error('[migrate] Fatal error:', err);
+  process.exit(1);
+});

--- a/skills/builtin/skill-creator/SKILL.md
+++ b/skills/builtin/skill-creator/SKILL.md
@@ -157,13 +157,13 @@ python3 /skills/builtin/skill-creator/scripts/init_skill.py my-skill-name
 python3 /skills/builtin/skill-creator/scripts/init_skill.py my-skill-name --resources scripts,references
 ```
 
-The script creates the skill under `/skills/custom/` by default.
+The script creates the skill under `/workspace/skills/` by default.
 
 **Option B** — Use file tools directly:
 
-Create `/skills/custom/<skill-name>/SKILL.md` with write_file, and optionally create `scripts/`, `references/`, `assets/` subdirectories.
+Create `/workspace/skills/<skill-name>/SKILL.md` with write_file, and optionally create `scripts/`, `references/`, `assets/` subdirectories.
 
-**Important:** Custom skills must be created under `/skills/custom/` (writable). `/skills/builtin/` is read-only.
+**Important:** Custom skills must be created under `/workspace/skills/` (writable). `/skills/builtin/` is read-only.
 
 ### Step 4: Edit the Skill
 
@@ -183,7 +183,7 @@ Write instructions for using the skill and its bundled resources.
 Run the validator to check the skill structure:
 
 ```bash
-python3 /skills/builtin/skill-creator/scripts/quick_validate.py /skills/custom/<skill-name>
+python3 /skills/builtin/skill-creator/scripts/quick_validate.py /workspace/skills/<skill-name>
 ```
 
 ### Step 6: Package the Skill (Optional)
@@ -191,7 +191,7 @@ python3 /skills/builtin/skill-creator/scripts/quick_validate.py /skills/custom/<
 Package a skill into a distributable `.skill` file:
 
 ```bash
-python3 /skills/builtin/skill-creator/scripts/package_skill.py /skills/custom/<skill-name>
+python3 /skills/builtin/skill-creator/scripts/package_skill.py /workspace/skills/<skill-name>
 ```
 
 ### Step 7: Iterate

--- a/skills/builtin/skill-creator/scripts/init_skill.py
+++ b/skills/builtin/skill-creator/scripts/init_skill.py
@@ -132,8 +132,8 @@ def main():
     parser.add_argument("skill_name", help="Skill name (normalized to hyphen-case)")
     parser.add_argument(
         "--path",
-        default="/skills/custom",
-        help="Output directory for the skill (default: /skills/custom)",
+        default="/workspace/skills",
+        help="Output directory for the skill (default: /workspace/skills)",
     )
     parser.add_argument(
         "--resources",


### PR DESCRIPTION
- Custom skills relocate from data/skills/custom/<userId>/ into <workspace>/skills/, riding the existing workspace mount.
- Adds full REST CRUD for skills via SkillsService with ScopedFs path-traversal protection.
- Lazy migration moves legacy skills on first agent run.
- Adds agent access-control enforcement on getAgent/listAgentRuns.
- Adds kimi-code provider (Anthropic SDK). Wires NEXT_PUBLIC_WS_URL through infra config.