### PR TITLE
fix(scripts): rebuild sibling Docker images in update.mjs

### DIFF
--- a/scripts/update.mjs
+++ b/scripts/update.mjs
@@ -109,6 +109,16 @@ async function main() {
     ok('Pulled');
   }
 
+  if (flags.build) {
+    step('Building agent Docker image');
+    runVisible('docker build -t clawix-agent:latest -f infra/docker/agent/Dockerfile .');
+    ok('clawix-agent:latest built');
+
+    step('Building python-runner Docker image');
+    runVisible('docker build -t clawix-python-runner:latest infra/docker/python-runner');
+    ok('clawix-python-runner:latest built');
+  }
+
   step('Restarting stack');
   const buildFlag = flags.build ? '--build' : '';
   runVisible(`docker compose -f "${composeFile}" up -d --remove-orphans ${buildFlag}`.trim());


### PR DESCRIPTION
Mirror install.mjs by rebuilding clawix-agent:latest and clawix-python-runner:latest on update. These are sibling images (not in compose), so 'docker compose up --build' alone left them stale. Gated behind --no-build to match the compose build skip.